### PR TITLE
Cache NPM packages on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "6.9.1"
+cache:
+  directories:
+    - node_modules # NPM packages
 install:
   - npm install
 script:


### PR DESCRIPTION
Enable Travis caching for NPM packages in the `node_modules` directory. This
should speed up CI build time.
