### PR TITLE
Remove Prism syntax highlighting

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
   "root": "src",
   "title": "Rusoto",
   "language": "en",
-  "plugins": ["-highlight", "-sharing", "edit-link", "prism"],
+  "plugins": ["-sharing", "edit-link"],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/rusoto/rusoto.github.io/tree/source/src",


### PR DESCRIPTION
Disable Prism syntax hightlighting plugin (because it can't highlight TOML).
Enable default GitBook syntax hightlighting plugin.
