### PR TITLE
Add basic documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "6.9.1"
+cache:
+  directories:
+    - node_modules # NPM packages
 install:
   - npm install
 script:

--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
   "root": "src",
   "title": "Rusoto",
   "language": "en",
-  "plugins": ["-highlight", "-sharing", "edit-link", "prism"],
+  "plugins": ["-sharing", "edit-link"],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/rusoto/rusoto.github.io/tree/source/src",

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,10 @@
 # Summary
 
 * [Overview](README.md)
-
+* [Help](help.md)
+* [Setting up Rusoto](setup.md)
+    * [On Stable Compiler](setup-stable.md)
+    * [On Nightly Compiler](setup-nightly.md)
+    * [Supporting Both](setup-hybrid.md)
+* [Usage & Example](usage-and-example.md)
+* [Supported AWS Services](supported-aws-services.md)

--- a/src/help.md
+++ b/src/help.md
@@ -1,0 +1,11 @@
+# Help
+
+If you are experiencing problems with rusoto, or would like clarification
+regarding something, please don't hesitate to contact us. You can reach us by
+[opening an issue][github-new-issue] on the GitHub page for the project with the
+relevant information (code snippets and error messages are very helpful!).
+Alternatively, you can join us on the `#rusoto` channel on
+[`irc.freenode.net`][freenode-webchat].
+
+[freenode-webchat]: https://webchat.freenode.net/
+[github-new-issue]: https://github.com/rusoto/rusoto/issues/new

--- a/src/setup-hybrid.md
+++ b/src/setup-hybrid.md
@@ -1,0 +1,34 @@
+# Supporting Both
+
+If you are using both nightly and stable versions of the Rust compiler, you can
+setup Rusoto to take advantage of [Serde's][serde] `serde_macros` for the
+codegen on nightly, while also using Syntex on stable. This approach is similar
+to the [stable approach][stable-approach], while also enabling active
+development to occur on nightly with the faster `serde_macros` method.
+
+Here is a `Cargo.toml` that depends on Rusoto's `unstable` features by default,
+but also exposes a [feature][cargo-feature] to depend on Syntex instead:
+
+```toml
+[package]
+name = "my-crate"
+version = "0.1.0"
+authors = ["My Name <my@email.com>"]
+
+[dependencies.rusoto]
+version = "0.18"
+default-features = false
+features = ["s3", "sqs"]
+
+[features]
+default = ["rusoto/unstable"]
+with-syntex = ["rusoto/with-syntex"]
+```
+
+This `Cargo.toml` allows you to build on nightly with `cargo build`, and on
+stable with the command:
+`cargo build --no-default-features --features with-syntex`.
+
+[cargo-feature]: http://doc.crates.io/manifest.html#the-features-section
+[serde]: https://github.com/serde-rs/serde
+[stable-approach]: https://rusoto.github.io/setup-stable.html

--- a/src/setup-nightly.md
+++ b/src/setup-nightly.md
@@ -1,0 +1,28 @@
+# On Nightly Compiler
+
+If you are using a nightly version of the compiler, you can setup Rusoto to use
+[Serde's][serde] `serde_macros` for the codegen.
+
+**Advantages of this approach**: none of the disadvantages of the
+[stable approach][stable-approach].
+
+**Disadvantages of this approach**: depends on an unstable Rust feature, so
+requires the usage of nightly Rust.
+
+To setup Rusoto to use this approach, use the following `Cargo.toml` as a
+starting point:
+
+```toml
+[package]
+name = "my-crate"
+version = "0.1.0"
+authors = ["My Name <my@email.com>"]
+
+[dependencies.rusoto]
+version = "0.18"
+default-features = false
+features = ["s3", "sqs", "unstable"]
+```
+
+[serde]: https://github.com/serde-rs/serde
+[stable-approach]: https://rusoto.github.io/setup-stable.html

--- a/src/setup-stable.md
+++ b/src/setup-stable.md
@@ -1,0 +1,29 @@
+# On Stable Compiler
+
+Currently, the stable Rust compiler does not support compiler plugins, so Rusoto
+uses [Syntex][syntex] along with a [Cargo build script][cargo-build-script] to
+be able to use [Serde][serde] on stable. In the future, this will no longer be
+necessary as support for compiler plugins matures.
+
+**Advantages of this approach**: supports stable & nightly Rust versions because
+it does not depend on any unstable features.
+
+**Disadvantages of this approach**: Syntex significantly increases compile time.
+
+To setup Rusoto to use this approach, use the following `Cargo.toml` as a
+starting point:
+
+```toml
+[package]
+name = "my-crate"
+version = "0.1.0"
+authors = ["My Name <my@email.com>"]
+
+[dependencies.rusoto]
+version = "0.18"
+features = ["s3", "sqs"]
+```
+
+[cargo-build-script]: http://doc.crates.io/build-script.html
+[serde]: https://github.com/serde-rs/serde
+[syntex]: https://serde.rs/technical-details.html#syntex

--- a/src/setup.md
+++ b/src/setup.md
@@ -1,0 +1,28 @@
+# Setting up Rusoto
+
+Rusoto uses [Serde][serde] to provide serialization/deserialization for the Rust
+data structures which represent the AWS API. Serde uses code generation in order
+to generate `Serialize` and `Deserialize` implementations.
+
+Serde allows for two separate ways of setting up code generation, depending on
+whether your crate will be used with stable or nightly Rust. For stable Rust,
+Serde uses a code generation library called [Syntex][syntex], along with a
+[Cargo build script][cargo-build-script] to write out the generated code to a
+file. For nightly Rust, Rusoto uses macros to generate the code.
+
+Rusoto takes advantage of this to provide a hybrid approach: Rusoto uses Syntex
+by default, but provides the ability to use macros on nightly Rust by using a
+Cargo [feature][cargo-feature]. Via this method, users can choose to either
+support stable and nightly, or both via feature flags.
+
+* [Setup Rusoto targetting stable compiler][setup-stable]
+* [Setup Rusoto targetting nightly compiler][setup-nightly]
+* [Supporting both stable and nightly][setup-hybrid]
+
+[cargo-build-script]: http://doc.crates.io/build-script.html
+[cargo-feature]: http://doc.crates.io/manifest.html#the-features-section
+[serde]: https://github.com/serde-rs/serde
+[setup-hybrid]: https://rusoto.github.io/setup-hybrid.html
+[setup-nightly]: https://rusoto.github.io/setup-nightly.html
+[setup-stable]: https://rusoto.github.io/setup-stable.html
+[syntex]: https://serde.rs/technical-details.html#syntex

--- a/src/supported-aws-services.md
+++ b/src/supported-aws-services.md
@@ -1,0 +1,43 @@
+# Supported AWS Services
+
+To use the a certain service, simply enable its cargo feature (listed below).
+
+Service | Cargo feature
+--------|--------------
+All supported services | all
+[Certificate Manager](https://aws.amazon.com/certificate-manager/) | acm
+[CloudHSM](https://aws.amazon.com/cloudhsm/) | cloudhsm
+[CloudTrail](https://aws.amazon.com/cloudtrail/) | cloudtrail
+[CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html) | events
+[CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CWL_GettingStarted.html) | logs
+[CodeCommit](https://aws.amazon.com/codecommit/) | codecommit
+[CodeDeploy](https://aws.amazon.com/codedeploy/) | codedeploy
+[CodePipeline](https://aws.amazon.com/codepipeline/) | codepipeline
+[Cognito Identity](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html) | cognito-identity
+[Config](https://aws.amazon.com/config/) | config
+[Data Pipeline](https://aws.amazon.com/datapipeline/) | datapipeline
+[Device Farm](https://aws.amazon.com/device-farm/) | devicefarm
+[Direct Connect](https://aws.amazon.com/directconnect/) | directconnect
+[Directory Service](https://aws.amazon.com/directoryservice/) | ds
+[DynamoDB](https://aws.amazon.com/dynamodb/) | dynamodb
+[DynamoDB Streams](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html) | dynamodbstreams
+[EC2](https://aws.amazon.com/ec2/) | ec2
+[EC2 Container Registry](https://aws.amazon.com/ecr/) | ecr
+[ECS](https://aws.amazon.com/ecs/) | ecs
+[Elastic MapReduce](https://aws.amazon.com/elasticmapreduce/) | emr
+[Elastic Transcoder](https://aws.amazon.com/elastictranscoder/) | ets
+[IAM](https://aws.amazon.com/iam/) | iam
+[Inspector](https://aws.amazon.com/inspector/) | inspector
+[Key Management Service](https://aws.amazon.com/kms/) | kms
+[Kinesis](https://aws.amazon.com/kinesis/) | kinesis
+[Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/) | firehose
+[Machine Learning](https://aws.amazon.com/machine-learning/) | machinelearning
+[OpsWorks](https://aws.amazon.com/opsworks/) | opsworks
+[Route53 Domains](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-domain-registrations.html) | route53domains
+[S3](https://aws.amazon.com/s3/) | s3
+[Simple Systems Manager](http://docs.aws.amazon.com/ssm/latest/APIReference/Welcome.html) | ssm
+[Simple Workflow Service](https://aws.amazon.com/swf/) | swf
+[SQS](https://aws.amazon.com/sqs/) | sqs
+[Storage Gateway](https://aws.amazon.com/storagegateway/) | storagegateway
+[Web Application Firewall](https://aws.amazon.com/waf/) | waf
+[WorkSpaces](https://aws.amazon.com/workspaces/) | workspaces

--- a/src/usage-and-example.md
+++ b/src/usage-and-example.md
@@ -1,0 +1,47 @@
+# Usage & Example
+
+Rusoto includes a public module for each AWS service it is compiled for, which
+contains the Rust types for that service's API. A full list of these services
+can be found on the [Supported AWS Services][supported-aws-services] page. All
+other public types are reexported to the crate root. Consult the rustdoc
+documentatation by running `cargo doc` or visiting the online
+[API documentation][api-documentation] for the latest crates.io release.
+
+A simple example of using Rusoto's DynamoDB API to list the names of all the
+tables in a database:
+
+```rust
+extern crate rusoto;
+
+use std::default::Default;
+
+use rusoto::{DefaultCredentialsProvider, Region};
+use rusoto::dynamodb::{DynamoDbClient, ListTablesInput};
+
+fn main() {
+  let provider = DefaultCredentialsProvider::new().unwrap();
+  let client = DynamoDbClient::new(provider, Region::UsEast1);
+  let list_tables_input: ListTablesInput = Default::default();
+
+  match client.list_tables(&list_tables_input) {
+    Ok(output) => {
+      match output.table_names {
+        Some(table_name_list) => {
+          println!("Tables in database:");
+
+          for table_name in table_name_list {
+            println!("{}", table_name);
+          }
+        }
+        None => println!("No tables in database!"),
+      }
+    }
+    Err(error) => {
+      println!("Error: {:?}", error);
+    }
+  }
+}
+```
+
+[api-documentation]: https://rusoto.github.io/rusoto/rusoto/
+[supported-aws-services]: https://rusoto.github.io/supported-aws-services.html


### PR DESCRIPTION
Add basic documentation for Rusoto, including: a help page, a setup page, a usage/example page, and a service list page.
Update table of contents.

@jimmycuadra @matthewkmayer @adimarco questions, comments? Looks good? I'm going to merge this in if no comments are provided as I think it's a decent start.

In general, I followed the layout of serde's GitBook: https://github.com/serde-rs/serde-rs.github.io.
