### PR TITLE
Add section on debugging

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -8,3 +8,4 @@
     * [Supporting Both](setup-hybrid.md)
 * [Usage & Example](usage-and-example.md)
 * [Supported AWS Services](supported-aws-services.md)
+* [Debugging](debugging.md)

--- a/src/debugging.md
+++ b/src/debugging.md
@@ -1,0 +1,40 @@
+# Debugging
+
+Rusoto uses the [log][log-repo] logging facade. For tests, Rusoto uses
+[`env_logger`][crates-io-env_logger].
+
+In order to see logging output (e.g. the actual requests made to AWS),
+`env_logger` needs to be initialized:
+
+```rust
+#[test]
+fn list_objects_test() {
+    let _ = env_logger::init(); // This initializes the `env_logger`
+
+    let bare_s3 = S3Client::new(
+        DefaultCredentialsProvider::new().unwrap(),
+        Region::UsWest2
+    );
+    let mut list_request = ListObjectsRequest::default();
+    list_request.bucket = "rusototester".to_string();
+    let result = bare_s3.list_objects(&list_request).unwrap();
+    println!("result is {:?}", result);
+}
+```
+
+To see the output of logging from integration tests, the command needs to be run
+as follows:
+
+```
+RUST_LOG=debug cargo test --features all
+```
+
+To get the logging output as well as the output of any `println!` statements,
+run:
+
+```
+RUST_LOG=debug cargo test --features all -- --nocapture
+```
+
+[crates-io-env_logger]: https://crates.io/crates/env_logger
+[log-repo]: https://github.com/rust-lang-nursery/log


### PR DESCRIPTION
Add a section on debugging. Includes information on enabling complete log output
as well as request logging.

Closes #1.
