### PR TITLE
Re-enable CNAME adding

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -17,7 +17,7 @@ git remote add upstream "https://$GH_TOKEN@github.com/rusoto/rusoto.github.io.gi
 git fetch upstream
 git reset upstream/master
 
-#echo "rusoto.rs" > CNAME
+echo "rusoto.org" > CNAME
 
 touch .
 


### PR DESCRIPTION
Re-enables the creation of a CNAME file in `publish.sh`. A CNAME file is
necessary so that the proper domains work.