### PR TITLE
Add branch explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ Alternatively, a static site can be built by running `npm run docs:build`.
 
 Any changes made to the documentation will automatically get published to GitHub
 Pages via Travis CI once the changes are merged onto master.
+
+# Branch Explanation
+
+This repo has a slightly unconventional branching setup. Most GitHub Pages-based
+repos tend to use `master` for the source, and `gh-pages` for the rendered
+website. Because this repo is intended to host an organization webpage, then per
+[GitHub's requirements](https://help.github.com/articles/user-organization-and-project-pages/)
+the source of the website MUST appear on the `master` branch. Since the `master`
+branch can no longer be used to hold the source, a separate branch must be made
+for that, which in this case is called `source`.


### PR DESCRIPTION
Add explanation of the branch naming scheme used in the repo to the `README.md`.
Closes #16.