### PR TITLE
Fix cross-domain links

### DIFF
--- a/book.json
+++ b/book.json
@@ -11,5 +11,8 @@
   },
   "structure": {
     "summary": "SUMMARY.md"
+  },
+  "variables": {
+    "domain": "http://rusoto.org"
   }
 }

--- a/src/README.md
+++ b/src/README.md
@@ -1,14 +1,17 @@
-<span style="float:right">[![github](/img/github.svg)](https://github.com/rusoto/rusoto) [![rustdoc](/img/rustdoc.svg)](https://rusoto.github.io/rusoto/rusoto/index.html) [![Latest Version](https://img.shields.io/crates/v/rusoto.svg?style=social)](https://crates.io/crates/rusoto)</span>
+<span style="float:right">[![github](/img/github.svg)](https://github.com/rusoto/rusoto) [![rustdoc](/img/rustdoc.svg)]({{ book.domain }}/rusoto/rusoto/) [![Latest Version](https://img.shields.io/crates/v/rusoto.svg?style=social)](https://crates.io/crates/rusoto)</span>
 
 # Rusoto
 
 Rusoto is an AWS SDK written in Rust.
 
-Rusoto consists of two main crates, [rusoto](https://github.com/rusoto/rusoto/)
-and [codegen](https://github.com/rusoto/rusoto/tree/master/codegen). The codegen
-crate programmatically generates the source for the API using the AWS API
-definitions provided by the [botocore](https://github.com/boto/botocore)
-project. This generated code is then used to construct the rusoto crate, which
-provides the low-level SDK functionality. Rusoto also provides a
-[helpers](https://github.com/rusoto/rusoto/tree/master/helpers) crate which
+Rusoto consists of two main crates, [rusoto][rusoto] and [codegen][codegen]. The
+codegen crate programmatically generates the source for the API using the AWS
+API definitions provided by the [botocore][botocore] project. This generated
+code is then used to construct the rusoto crate, which provides the low-level
+SDK functionality. Rusoto also provides a [helpers][helpers] crate which
 provides higher-level abstractions for some of the AWS services (e.g. S3).
+
+[rusoto]: https://github.com/rusoto/rusoto "Rusoto"
+[codegen]: https://github.com/rusoto/rusoto/tree/master/codegen "Rusoto codegen"
+[botocore]: https://github.com/boto/botocore "Botocore"
+[helpers]: https://github.com/rusoto/rusoto/tree/master/helpers "Rusoto helpers"

--- a/src/setup-hybrid.md
+++ b/src/setup-hybrid.md
@@ -31,4 +31,4 @@ stable with the command:
 
 [cargo-feature]: http://doc.crates.io/manifest.html#the-features-section
 [serde]: https://github.com/serde-rs/serde
-[stable-approach]: https://rusoto.github.io/setup-stable.html
+[stable-approach]: /setup-stable.html

--- a/src/setup-nightly.md
+++ b/src/setup-nightly.md
@@ -25,4 +25,4 @@ features = ["s3", "sqs", "unstable"]
 ```
 
 [serde]: https://github.com/serde-rs/serde
-[stable-approach]: https://rusoto.github.io/setup-stable.html
+[stable-approach]: /setup-stable.html

--- a/src/setup.md
+++ b/src/setup.md
@@ -22,7 +22,7 @@ support stable and nightly, or both via feature flags.
 [cargo-build-script]: http://doc.crates.io/build-script.html
 [cargo-feature]: http://doc.crates.io/manifest.html#the-features-section
 [serde]: https://github.com/serde-rs/serde
-[setup-hybrid]: https://rusoto.github.io/setup-hybrid.html
-[setup-nightly]: https://rusoto.github.io/setup-nightly.html
-[setup-stable]: https://rusoto.github.io/setup-stable.html
+[setup-hybrid]: /setup-hybrid.html
+[setup-nightly]: /setup-nightly.html
+[setup-stable]: /setup-stable.html
 [syntex]: https://serde.rs/technical-details.html#syntex

--- a/src/usage-and-example.md
+++ b/src/usage-and-example.md
@@ -43,5 +43,5 @@ fn main() {
 }
 ```
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/
-[supported-aws-services]: https://rusoto.github.io/supported-aws-services.html
+[api-documentation]: {{ book.domain }}/rusoto/rusoto/
+[supported-aws-services]: /supported-aws-services.html


### PR DESCRIPTION
Replace cross-domain links with relative links, so that following links
throughout the GitBook doesn't result in new tabs being opened.
Replace certain hard-coded markdown links with reference-style links.

Closes #15.