### PR TITLE
Replace serde_macros with serde_derive

### DIFF
--- a/src/setup-hybrid.md
+++ b/src/setup-hybrid.md
@@ -1,10 +1,10 @@
 # Supporting Both
 
 If you are using both nightly and stable versions of the Rust compiler, you can
-setup Rusoto to take advantage of [Serde's][serde] `serde_macros` for the
+setup Rusoto to take advantage of [Serde's][serde] `serde_derive` for the
 codegen on nightly, while also using Syntex on stable. This approach is similar
 to the [stable approach][stable-approach], while also enabling active
-development to occur on nightly with the faster `serde_macros` method.
+development to occur on nightly with the faster `serde_derive` method.
 
 Here is a `Cargo.toml` that depends on Rusoto's `unstable` features by default,
 but also exposes a [feature][cargo-feature] to depend on Syntex instead:

--- a/src/setup-nightly.md
+++ b/src/setup-nightly.md
@@ -1,7 +1,7 @@
 # On Nightly Compiler
 
 If you are using a nightly version of the compiler, you can setup Rusoto to use
-[Serde's][serde] `serde_macros` for the codegen.
+[Serde's][serde] `serde_derive` for the codegen.
 
 **Advantages of this approach**: none of the disadvantages of the
 [stable approach][stable-approach].

--- a/src/setup.md
+++ b/src/setup.md
@@ -11,9 +11,9 @@ Serde uses a code generation library called [Syntex][syntex], along with a
 file. For nightly Rust, Rusoto uses macros to generate the code.
 
 Rusoto takes advantage of this to provide a hybrid approach: Rusoto uses Syntex
-by default, but provides the ability to use macros on nightly Rust by using a
-Cargo [feature][cargo-feature]. Via this method, users can choose to either
-support stable and nightly, or both via feature flags.
+by default, but provides the ability to use macros for code generation on
+nightly Rust by using a Cargo [feature][cargo-feature]. Via this method, users
+can choose to either support stable and nightly, or both via feature flags.
 
 * [Setup Rusoto targetting stable compiler][setup-stable]
 * [Setup Rusoto targetting nightly compiler][setup-nightly]


### PR DESCRIPTION
Update all references to `serde_macros` with `serde_derive`.
Clarify macro usage information.

Closes #19.