### PR TITLE
Update cargo links.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-<span style="float:right">[![github](/img/github.svg)](https://github.com/rusoto/rusoto) [![rustdoc](/img/rustdoc.svg)](https://rusoto.github.io/rusoto/rusoto/) [![Latest Version](https://img.shields.io/crates/v/rusoto.svg?style=social)](https://crates.io/crates/rusoto)</span>
+<span style="float:right">[![github](/img/github.svg)](https://github.com/rusoto/rusoto) [![rustdoc](/img/rustdoc.svg)](https://rusoto.github.io/rusoto/rusoto/) [![Latest Version](https://img.shields.io/crates/v/rusoto_core.svg?style=social)](https://crates.io/crates/rusoto_core)</span>
 
 # Rusoto
 


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto.github.io/issues/55 .