### PR TITLE
Update supported AWS services for Rusoto 0.26.0.

### DIFF
--- a/src/supported-aws-services.md
+++ b/src/supported-aws-services.md
@@ -5,6 +5,7 @@
 
 Service | Crate | Stability
 --------|---------------|---------
+[AppStream](https://aws.amazon.com/appstream2/) | [rusoto_appstream](https://crates.io/crates/rusoto_appstream) | Needs improvement
 [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/) | [rusoto_elbv2](https://crates.io/crates/rusoto_elbv2) | Needs improvement
 [Autoscaling](https://aws.amazon.com/autoscaling/) | [rusoto_autoscaling](https://crates.io/crates/rusoto_autoscaling) | Needs improvement
 [Certificate Manager](https://aws.amazon.com/certificate-manager/) | [rusoto_acm](https://crates.io/crates/rusoto_acm) | Needs improvement
@@ -16,11 +17,15 @@ Service | Crate | Stability
 [CloudWatch](https://aws.amazon.com/cloudwatch/) | [rusoto_cloudwatch](https://crates.io/crates/rusoto_cloudwatch) | Needs improvement
 [CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html) | [rusoto_events](https://crates.io/crates/rusoto_events) | Needs improvement 
 [CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CWL_GettingStarted.html) | [rusoto_logs](https://crates.io/crates/rusoto_logs) | Needs improvement 
+[CodeBuild](https://aws.amazon.com/codebuild/) | [rusoto_codebuild](https://crates.io/crates/rusoto_codebuild) | Needs improvement
 [CodeCommit](https://aws.amazon.com/codecommit/) | [rusoto_codecommit](https://crates.io/crates/rusoto_codecommit) | Needs improvement
 [CodeDeploy](https://aws.amazon.com/codedeploy/) | [rusoto_codedeploy](https://crates.io/crates/rusoto_codedeploy) | Needs improvement
 [CodePipeline](https://aws.amazon.com/codepipeline/) | [rusoto_codepipeline](https://crates.io/crates/rusoto_codepipeline) | Needs improvement
 [Cognito Identity](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito-identity) | Needs improvement 
+[Cognito Identity Provider](http://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/Welcome.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito_idp) | Needs improvement
 [Config](https://aws.amazon.com/config/) | [rusoto_config](https://crates.io/crates/rusoto_config) | Needs improvement
+[Cost and Usage Report](https://aws.amazon.com/about-aws/whats-new/2015/12/aws-cost-and-usage-reports-comprehensive-and-customizable-reporting-on-your-aws-costs-and-cost-drivers/) | [rusoto_cur](https://crates.io/crates/rusoto_cur) | Needs improvement
+[Database Migration Service](https://aws.amazon.com/dms/) | [rusoto_dms](https://crates.io/crates/rusoto_dms) | Needs improvement
 [Data Pipeline](https://aws.amazon.com/datapipeline/) | [rusoto_datapipeline](https://crates.io/crates/rusoto_datapipeline) | Needs improvement
 [Device Farm](https://aws.amazon.com/device-farm/) | [rusoto_devicefarm](https://crates.io/crates/rusoto_devicefarm) | Needs improvement
 [Direct Connect](https://aws.amazon.com/directconnect/) | [rusoto_directconnect](https://crates.io/crates/rusoto_directconnect) | Needs improvement
@@ -38,25 +43,41 @@ Service | Crate | Stability
 [IAM](https://aws.amazon.com/iam/) | [rusoto_iam](https://crates.io/crates/rusoto_iam) | Needs improvement
 [Import Export](https://aws.amazon.com/documentation/importexport/) | [rusoto_importexport](https://crates.io/crates/rusoto_importexport) | Needs improvement
 [Inspector](https://aws.amazon.com/inspector/) | [rusoto_inspector](https://crates.io/crates/rusoto_inspector) | Needs improvement
+[GameLift](https://aws.amazon.com/gamelift/) | [rusoto_gamelift](https://crates.io/crates/rusoto_gamelift) | Needs improvement
+[Health APIs and Notifications](http://docs.aws.amazon.com/IAM/latest/UserGuide/list_health.html) | [rusoto_health](https://crates.io/crates/rusoto_health) | Needs improvement
 [IoT](https://aws.amazon.com/iot/) | [rusoto_iot](https://crates.io/crates/rusoto_iot) | Needs improvement
 [Key Management Service](https://aws.amazon.com/kms/) | [rusoto_kms](https://crates.io/crates/rusoto_kms) | Stable
 [Kinesis](https://aws.amazon.com/kinesis/) | [rusoto_kinesis](https://crates.io/crates/rusoto_kinesis) | Needs improvement
+[Kinesis Analytics](https://aws.amazon.com/kinesis/analytics/) | [rusoto_kinesisanalytics](https://crates.io/crates/rusoto_kinesisanalytics) | Needs improvement
 [Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/) | [rusoto_firehose](https://crates.io/crates/rusoto_firehose) | Needs improvement
 [Lambda](https://aws.amazon.com/lambda/) | [rusoto_lambda](https://crates.io/crates/rusoto_lambda) | Needs improvement
+[Lightsail](https://amazonlightsail.com/) | [rusoto_lightsail](https://crates.io/crates/rusoto_lightsail) | Needs improvement
 [Machine Learning](https://aws.amazon.com/machine-learning/) | [rusoto_machinelearning](https://crates.io/crates/rusoto_machinelearning) | Needs improvement 
 [Marketplace Commerce Analytics](https://s3.amazonaws.com/awsmp-loadforms/AWS-Marketplace-Commerce-Analytics-Service-Onboarding-and-Technical-Guide.pdf) | [rusoto_marketplacecommerceanalytics](https://crates.io/crates/rusoto_marketplacecommerceanalytics) | Needs improvement
+[AWSMarketplace Metering](http://docs.aws.amazon.com/marketplacemetering/latest/APIReference/Welcome.html) | [rusoto_meteringmarketplace](https://crates.io/crates/rusoto_meteringmarketplace) | Needs improvement
 [OpsWorks](https://aws.amazon.com/opsworks/) | [rusoto_opsworks](https://crates.io/crates/rusoto_opsworks) | Needs improvement
+[OpsWorks for Chef Automate](https://aws.amazon.com/opsworks/chefautomate/) | [rusoto_opsworkscm](https://crates.io/crates/rusoto_opsworkscm) | Needs improvement
+[Organizations](https://aws.amazon.com/organizations/) | [rusoto_organizations](https://crates.io/crates/rusoto_organizations) | Needs improvement
 [Redshift](https://aws.amazon.com/redshift/) | [rusoto_redshift](https://crates.io/crates/rusoto_redshift) | Needs improvement
+[Rekognition](https://aws.amazon.com/rekognition/) | [rusoto_rekognition](https://crates.io/crates/rusoto_rekognition) | Needs improvement
 [RDS](https://aws.amazon.com/rds/) | [rusoto_rds](https://crates.io/crates/rusoto_rds) | Needs improvement
 [Route53](https://aws.amazon.com/route53/) | [rusoto_route53](https://crates.io/crates/rusoto_route53) | Needs improvement
 [Route53 Domains](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-domain-registrations.html) | [rusoto_route53domains](https://crates.io/crates/rusoto_route53domains) | Needs improvement 
 [S3](https://aws.amazon.com/s3/) | [rusoto_s3](https://crates.io/crates/rusoto_s3) | Needs improvement
 [SDB](https://aws.amazon.com/simpledb/) | [rusoto_sdb](https://crates.io/crates/rusoto_sdb) | Needs improvement
+[Service Catalog](https://aws.amazon.com/servicecatalog/) | [rusoto_servicecatalog](https://crates.io/crates/rusoto_servicecatalog) | Needs improvement
+[Simple Email Service](https://aws.amazon.com/ses/) | [rusoto_ses](https://crates.io/crates/rusoto_ses) | Needs improvement
 [Simple Notification Service](https://aws.amazon.com/sns/) | [rusoto_sns](https://crates.io/crates/rusoto_sns) | Needs improvement
 [Simple Systems Manager](http://docs.aws.amazon.com/ssm/latest/APIReference/Welcome.html) | [rusoto_ssm](https://crates.io/crates/rusoto_ssm) | Needs improvement 
+[Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) | [rusoto_sts](https://crates.io/crates/rusoto_sts) | Needs improvement
 [Simple Workflow Service](https://aws.amazon.com/swf/) | [rusoto_swf](https://crates.io/crates/rusoto_swf) | Needs improvement
+[Server Migration Service](https://aws.amazon.com/server-migration-service/) | [rusoto_sms](https://crates.io/crates/rusoto_sms) | Needs improvement
+[Snowball](https://aws.amazon.com/snowball/) | [rusoto_snowball](https://crates.io/crates/rusoto_snowball) | Needs improvement
+[Step Functions](https://aws.amazon.com/step-functions/) | [rusoto_stepfunctions](https://crates.io/crates/rusoto_stepfunctions) | Needs improvement
 [Storage Gateway](https://aws.amazon.com/storagegateway/) | [rusoto_storagegateway](https://crates.io/crates/rusoto_storagegateway) | Needs improvement
 [SQS](https://aws.amazon.com/sqs/) | [rusoto_sqs](https://crates.io/crates/rusoto_sqs) | Stable
 [Storage Gateway](https://aws.amazon.com/storagegateway/) | [rusoto_storagegateway](https://crates.io/crates/rusoto_storagegateway) | Needs improvement
+[Support](http://docs.aws.amazon.com/awssupport/latest/user/Welcome.html) | [rusoto_support](https://crates.io/crates/rusoto_support) | Needs improvement
 [Web Application Firewall](https://aws.amazon.com/waf/) | [rusoto_waf](https://crates.io/crates/rusoto_waf) | Needs improvement
+[Web Application Firewall Regional](http://docs.aws.amazon.com/waf/latest/APIReference/API_Operations_AWS_WAF_Regional.html) | [rusoto_waf_regional](https://crates.io/crates/rusoto_waf_regional) | Needs improvement
 [WorkSpaces](https://aws.amazon.com/workspaces/) | [rusoto_workspaces](https://crates.io/crates/rusoto_workspaces) | Needs improvement


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto.github.io/issues/61 .  Probably needs a double check for alphabetizing everything.