### PR TITLE
 Update supported AWS services for Rusoto

### DIFF
--- a/src/supported-aws-services.md
+++ b/src/supported-aws-services.md
@@ -7,7 +7,9 @@ Service | Crate | Stability
 --------|---------------|---------
 [AppStream](https://aws.amazon.com/appstream2/) | [rusoto_appstream](https://crates.io/crates/rusoto_appstream) | Needs improvement
 [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/) | [rusoto_elbv2](https://crates.io/crates/rusoto_elbv2) | Needs improvement
+[API Gateway](https://aws.amazon.com/api-gateway/) | [rusoto_apigateway](https://crates.io/crates/rusoto_apigateway) | Needs improvement
 [Autoscaling](https://aws.amazon.com/autoscaling/) | [rusoto_autoscaling](https://crates.io/crates/rusoto_autoscaling) | Needs improvement
+[Batch](https://aws.amazon.com/batch/) | [rusoto_batch](https://crates.io/crates/rusoto_batch) | Needs improvement
 [Certificate Manager](https://aws.amazon.com/certificate-manager/) | [rusoto_acm](https://crates.io/crates/rusoto_acm) | Needs improvement
 [CloudFormation](https://aws.amazon.com/cloudformation/) | [rusoto_cloudformation](https://crates.io/crates/rusoto_cloudformation) | Needs improvement
 [CloudFront](https://aws.amazon.com/cloudfront/) | [rusoto_cloudfront](https://crates.io/crates/rusoto_cloudfront) | Needs improvement
@@ -25,6 +27,7 @@ Service | Crate | Stability
 [Cognito Identity Provider](http://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/Welcome.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito_idp) | Needs improvement
 [Config](https://aws.amazon.com/config/) | [rusoto_config](https://crates.io/crates/rusoto_config) | Needs improvement
 [Cost and Usage Report](https://aws.amazon.com/about-aws/whats-new/2015/12/aws-cost-and-usage-reports-comprehensive-and-customizable-reporting-on-your-aws-costs-and-cost-drivers/) | [rusoto_cur](https://crates.io/crates/rusoto_cur) | Needs improvement
+[Credential](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html) | [rusiti_credential](https://crates.io/crates/rusoto_credential) | Needs improvement
 [Database Migration Service](https://aws.amazon.com/dms/) | [rusoto_dms](https://crates.io/crates/rusoto_dms) | Needs improvement
 [Data Pipeline](https://aws.amazon.com/datapipeline/) | [rusoto_datapipeline](https://crates.io/crates/rusoto_datapipeline) | Needs improvement
 [Device Farm](https://aws.amazon.com/device-farm/) | [rusoto_devicefarm](https://crates.io/crates/rusoto_devicefarm) | Needs improvement
@@ -38,12 +41,13 @@ Service | Crate | Stability
 [ElastiCache](https://aws.amazon.com/elasticache/) | [rusoto_elasticache](https://crates.io/crates/rusoto_elasticache) | Needs improvement
 [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/) | [rusoto_elasticbeanstalk](https://crates.io/crates/rusoto_elasticbeanstalk) | Needs improvement
 [Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/) | [rusoto_elb](https://crates.io/crates/rusoto_elb) | Needs improvement
-[Elastic MapReduce](https://aws.amazon.com/elasticmapreduce/) | [rusoto_emr](https://crates.io/crates/rusoto_emr) | Needs improvement 
+[Elastic MapReduce](https://aws.amazon.com/elasticmapreduce/) | [rusoto_emr](https://crates.io/crates/rusoto_emr) | Needs improvement
 [Elastic Transcoder](https://aws.amazon.com/elastictranscoder/) | [rusoto_ets](https://crates.io/crates/rusoto_ets) | Stable
 [IAM](https://aws.amazon.com/iam/) | [rusoto_iam](https://crates.io/crates/rusoto_iam) | Needs improvement
 [Import Export](https://aws.amazon.com/documentation/importexport/) | [rusoto_importexport](https://crates.io/crates/rusoto_importexport) | Needs improvement
 [Inspector](https://aws.amazon.com/inspector/) | [rusoto_inspector](https://crates.io/crates/rusoto_inspector) | Needs improvement
 [GameLift](https://aws.amazon.com/gamelift/) | [rusoto_gamelift](https://crates.io/crates/rusoto_gamelift) | Needs improvement
+[Glacier](https://aws.amazon.com/glacier/) | [rusoto_glacier](https://crates.io/crates/rusoto_glacier) | Needs improvement
 [Health APIs and Notifications](http://docs.aws.amazon.com/IAM/latest/UserGuide/list_health.html) | [rusoto_health](https://crates.io/crates/rusoto_health) | Needs improvement
 [IoT](https://aws.amazon.com/iot/) | [rusoto_iot](https://crates.io/crates/rusoto_iot) | Needs improvement
 [Key Management Service](https://aws.amazon.com/kms/) | [rusoto_kms](https://crates.io/crates/rusoto_kms) | Stable
@@ -54,10 +58,12 @@ Service | Crate | Stability
 [Lightsail](https://amazonlightsail.com/) | [rusoto_lightsail](https://crates.io/crates/rusoto_lightsail) | Needs improvement
 [Machine Learning](https://aws.amazon.com/machine-learning/) | [rusoto_machinelearning](https://crates.io/crates/rusoto_machinelearning) | Needs improvement 
 [Marketplace Commerce Analytics](https://s3.amazonaws.com/awsmp-loadforms/AWS-Marketplace-Commerce-Analytics-Service-Onboarding-and-Technical-Guide.pdf) | [rusoto_marketplacecommerceanalytics](https://crates.io/crates/rusoto_marketplacecommerceanalytics) | Needs improvement
-[AWSMarketplace Metering](http://docs.aws.amazon.com/marketplacemetering/latest/APIReference/Welcome.html) | [rusoto_meteringmarketplace](https://crates.io/crates/rusoto_meteringmarketplace) | Needs improvement
+[Marketplace Metering](http://docs.aws.amazon.com/marketplacemetering/latest/APIReference/Welcome.html) | [rusoto_meteringmarketplace](https://crates.io/crates/rusoto_meteringmarketplace) | Needs improvement
+[Mechanical Turk](https://aws.amazon.com/documentation/mturk/) | [rusoto_mturk](https://crates.io/crates/rusoto_mturk) | Needs improvement
 [OpsWorks](https://aws.amazon.com/opsworks/) | [rusoto_opsworks](https://crates.io/crates/rusoto_opsworks) | Needs improvement
 [OpsWorks for Chef Automate](https://aws.amazon.com/opsworks/chefautomate/) | [rusoto_opsworkscm](https://crates.io/crates/rusoto_opsworkscm) | Needs improvement
 [Organizations](https://aws.amazon.com/organizations/) | [rusoto_organizations](https://crates.io/crates/rusoto_organizations) | Needs improvement
+[Polly](https://aws.amazon.com/polly/) | [rusoto_polly](https://crates.io/crates/rusoto_polly) | Needs improvement
 [Redshift](https://aws.amazon.com/redshift/) | [rusoto_redshift](https://crates.io/crates/rusoto_redshift) | Needs improvement
 [Rekognition](https://aws.amazon.com/rekognition/) | [rusoto_rekognition](https://crates.io/crates/rusoto_rekognition) | Needs improvement
 [RDS](https://aws.amazon.com/rds/) | [rusoto_rds](https://crates.io/crates/rusoto_rds) | Needs improvement

--- a/src/supported-aws-services.md
+++ b/src/supported-aws-services.md
@@ -1,7 +1,7 @@
 # Supported AWS Services
 
-**Stable:** service has not caused many bug reports.  
-**Needs improvement:** service has either generated many bug reports and/or is a little-used service in Rusoto. 
+**Stable:** service has not caused many bug reports.
+**Needs improvement:** service has either generated many bug reports and/or is a little-used service in Rusoto.
 
 Service | Crate | Stability
 --------|---------------|---------
@@ -17,13 +17,13 @@ Service | Crate | Stability
 [CloudSearch](https://aws.amazon.com/cloudsearch/) | [rusoto_cloudsearch](https://crates.io/crates/rusoto_cloudsearch) | Needs improvement
 [CloudTrail](https://aws.amazon.com/cloudtrail/) | [rusoto_cloudtrail](https://crates.io/crates/rusoto_cloudtrail) | Needs improvement
 [CloudWatch](https://aws.amazon.com/cloudwatch/) | [rusoto_cloudwatch](https://crates.io/crates/rusoto_cloudwatch) | Needs improvement
-[CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html) | [rusoto_events](https://crates.io/crates/rusoto_events) | Needs improvement 
-[CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CWL_GettingStarted.html) | [rusoto_logs](https://crates.io/crates/rusoto_logs) | Needs improvement 
+[CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html) | [rusoto_events](https://crates.io/crates/rusoto_events) | Needs improvement
+[CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CWL_GettingStarted.html) | [rusoto_logs](https://crates.io/crates/rusoto_logs) | Needs improvement
 [CodeBuild](https://aws.amazon.com/codebuild/) | [rusoto_codebuild](https://crates.io/crates/rusoto_codebuild) | Needs improvement
 [CodeCommit](https://aws.amazon.com/codecommit/) | [rusoto_codecommit](https://crates.io/crates/rusoto_codecommit) | Needs improvement
 [CodeDeploy](https://aws.amazon.com/codedeploy/) | [rusoto_codedeploy](https://crates.io/crates/rusoto_codedeploy) | Needs improvement
 [CodePipeline](https://aws.amazon.com/codepipeline/) | [rusoto_codepipeline](https://crates.io/crates/rusoto_codepipeline) | Needs improvement
-[Cognito Identity](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito-identity) | Needs improvement 
+[Cognito Identity](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito-identity) | Needs improvement
 [Cognito Identity Provider](http://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/Welcome.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito_idp) | Needs improvement
 [Config](https://aws.amazon.com/config/) | [rusoto_config](https://crates.io/crates/rusoto_config) | Needs improvement
 [Cost and Usage Report](https://aws.amazon.com/about-aws/whats-new/2015/12/aws-cost-and-usage-reports-comprehensive-and-customizable-reporting-on-your-aws-costs-and-cost-drivers/) | [rusoto_cur](https://crates.io/crates/rusoto_cur) | Needs improvement
@@ -34,7 +34,7 @@ Service | Crate | Stability
 [Direct Connect](https://aws.amazon.com/directconnect/) | [rusoto_directconnect](https://crates.io/crates/rusoto_directconnect) | Needs improvement
 [Directory Service](https://aws.amazon.com/directoryservice/) | [rusoto_ds](https://crates.io/crates/rusoto_ds) | Needs improvement
 [DynamoDB](https://aws.amazon.com/dynamodb/) | [rusoto_dynamodb](https://crates.io/crates/rusoto_dynamodb) | Stable
-[DynamoDB Streams](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html) | [rusoto_dynamodbstreams](https://crates.io/crates/rusoto_dynamodbstreams) | Needs improvement 
+[DynamoDB Streams](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html) | [rusoto_dynamodbstreams](https://crates.io/crates/rusoto_dynamodbstreams) | Needs improvement
 [EC2](https://aws.amazon.com/ec2/) | [rusoto_ec2](https://crates.io/crates/rusoto_ec2) | Stable
 [EC2 Container Registry](https://aws.amazon.com/ecr/) | [rusoto_ecr](https://crates.io/crates/rusoto_ecr) | Needs improvement
 [ECS](https://aws.amazon.com/ecs/) | [rusoto_ecs](https://crates.io/crates/rusoto_ecs) | Stable
@@ -56,10 +56,11 @@ Service | Crate | Stability
 [Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/) | [rusoto_firehose](https://crates.io/crates/rusoto_firehose) | Needs improvement
 [Lambda](https://aws.amazon.com/lambda/) | [rusoto_lambda](https://crates.io/crates/rusoto_lambda) | Needs improvement
 [Lightsail](https://amazonlightsail.com/) | [rusoto_lightsail](https://crates.io/crates/rusoto_lightsail) | Needs improvement
-[Machine Learning](https://aws.amazon.com/machine-learning/) | [rusoto_machinelearning](https://crates.io/crates/rusoto_machinelearning) | Needs improvement 
+[Machine Learning](https://aws.amazon.com/machine-learning/) | [rusoto_machinelearning](https://crates.io/crates/rusoto_machinelearning) | Needs improvement
 [Marketplace Commerce Analytics](https://s3.amazonaws.com/awsmp-loadforms/AWS-Marketplace-Commerce-Analytics-Service-Onboarding-and-Technical-Guide.pdf) | [rusoto_marketplacecommerceanalytics](https://crates.io/crates/rusoto_marketplacecommerceanalytics) | Needs improvement
 [Marketplace Metering](http://docs.aws.amazon.com/marketplacemetering/latest/APIReference/Welcome.html) | [rusoto_meteringmarketplace](https://crates.io/crates/rusoto_meteringmarketplace) | Needs improvement
 [Mechanical Turk](https://aws.amazon.com/documentation/mturk/) | [rusoto_mturk](https://crates.io/crates/rusoto_mturk) | Needs improvement
+[Migration Hub](https://aws.amazon.com/migration-hub/) | [rusoto_mgh]() | Needs improvement
 [OpsWorks](https://aws.amazon.com/opsworks/) | [rusoto_opsworks](https://crates.io/crates/rusoto_opsworks) | Needs improvement
 [OpsWorks for Chef Automate](https://aws.amazon.com/opsworks/chefautomate/) | [rusoto_opsworkscm](https://crates.io/crates/rusoto_opsworkscm) | Needs improvement
 [Organizations](https://aws.amazon.com/organizations/) | [rusoto_organizations](https://crates.io/crates/rusoto_organizations) | Needs improvement
@@ -68,13 +69,13 @@ Service | Crate | Stability
 [Rekognition](https://aws.amazon.com/rekognition/) | [rusoto_rekognition](https://crates.io/crates/rusoto_rekognition) | Needs improvement
 [RDS](https://aws.amazon.com/rds/) | [rusoto_rds](https://crates.io/crates/rusoto_rds) | Needs improvement
 [Route53](https://aws.amazon.com/route53/) | [rusoto_route53](https://crates.io/crates/rusoto_route53) | Needs improvement
-[Route53 Domains](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-domain-registrations.html) | [rusoto_route53domains](https://crates.io/crates/rusoto_route53domains) | Needs improvement 
+[Route53 Domains](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-domain-registrations.html) | [rusoto_route53domains](https://crates.io/crates/rusoto_route53domains) | Needs improvement
 [S3](https://aws.amazon.com/s3/) | [rusoto_s3](https://crates.io/crates/rusoto_s3) | Needs improvement
 [SDB](https://aws.amazon.com/simpledb/) | [rusoto_sdb](https://crates.io/crates/rusoto_sdb) | Needs improvement
 [Service Catalog](https://aws.amazon.com/servicecatalog/) | [rusoto_servicecatalog](https://crates.io/crates/rusoto_servicecatalog) | Needs improvement
 [Simple Email Service](https://aws.amazon.com/ses/) | [rusoto_ses](https://crates.io/crates/rusoto_ses) | Needs improvement
 [Simple Notification Service](https://aws.amazon.com/sns/) | [rusoto_sns](https://crates.io/crates/rusoto_sns) | Needs improvement
-[Simple Systems Manager](http://docs.aws.amazon.com/ssm/latest/APIReference/Welcome.html) | [rusoto_ssm](https://crates.io/crates/rusoto_ssm) | Needs improvement 
+[Simple Systems Manager](http://docs.aws.amazon.com/ssm/latest/APIReference/Welcome.html) | [rusoto_ssm](https://crates.io/crates/rusoto_ssm) | Needs improvement
 [Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) | [rusoto_sts](https://crates.io/crates/rusoto_sts) | Needs improvement
 [Simple Workflow Service](https://aws.amazon.com/swf/) | [rusoto_swf](https://crates.io/crates/rusoto_swf) | Needs improvement
 [Server Migration Service](https://aws.amazon.com/server-migration-service/) | [rusoto_sms](https://crates.io/crates/rusoto_sms) | Needs improvement

--- a/src/supported-aws-services.md
+++ b/src/supported-aws-services.md
@@ -6,15 +6,18 @@
 Service | Crate | Stability
 --------|---------------|---------
 [AppStream](https://aws.amazon.com/appstream2/) | [rusoto_appstream](https://crates.io/crates/rusoto_appstream) | Needs improvement
+[Application Discovery Service](https://aws.amazon.com/application-discovery/) | []() | Needs improvement
 [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/) | [rusoto_elbv2](https://crates.io/crates/rusoto_elbv2) | Needs improvement
 [API Gateway](https://aws.amazon.com/api-gateway/) | [rusoto_apigateway](https://crates.io/crates/rusoto_apigateway) | Needs improvement
 [Autoscaling](https://aws.amazon.com/autoscaling/) | [rusoto_autoscaling](https://crates.io/crates/rusoto_autoscaling) | Needs improvement
 [Batch](https://aws.amazon.com/batch/) | [rusoto_batch](https://crates.io/crates/rusoto_batch) | Needs improvement
 [Certificate Manager](https://aws.amazon.com/certificate-manager/) | [rusoto_acm](https://crates.io/crates/rusoto_acm) | Needs improvement
+[Cloud Directory](https://aws.amazon.com/cloud-directory/) | []() | Needs improvement
 [CloudFormation](https://aws.amazon.com/cloudformation/) | [rusoto_cloudformation](https://crates.io/crates/rusoto_cloudformation) | Needs improvement
 [CloudFront](https://aws.amazon.com/cloudfront/) | [rusoto_cloudfront](https://crates.io/crates/rusoto_cloudfront) | Needs improvement
 [CloudHSM](https://aws.amazon.com/cloudhsm/) | [rusoto_cloudhsm](https://crates.io/crates/rusoto_cloudhsm) | Needs improvement
 [CloudSearch](https://aws.amazon.com/cloudsearch/) | [rusoto_cloudsearch](https://crates.io/crates/rusoto_cloudsearch) | Needs improvement
+[CloudSearch Domains](http://docs.aws.amazon.com/cloudsearch/latest/developerguide/creating-managing-domains.html) | []() | Needs improvement
 [CloudTrail](https://aws.amazon.com/cloudtrail/) | [rusoto_cloudtrail](https://crates.io/crates/rusoto_cloudtrail) | Needs improvement
 [CloudWatch](https://aws.amazon.com/cloudwatch/) | [rusoto_cloudwatch](https://crates.io/crates/rusoto_cloudwatch) | Needs improvement
 [CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html) | [rusoto_events](https://crates.io/crates/rusoto_events) | Needs improvement
@@ -25,6 +28,7 @@ Service | Crate | Stability
 [CodePipeline](https://aws.amazon.com/codepipeline/) | [rusoto_codepipeline](https://crates.io/crates/rusoto_codepipeline) | Needs improvement
 [Cognito Identity](http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito-identity) | Needs improvement
 [Cognito Identity Provider](http://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/Welcome.html) | [rusoto_cognito-identity](https://crates.io/crates/rusoto_cognito_idp) | Needs improvement
+[Cognito Sync](http://docs.aws.amazon.com/cognitosync/latest/APIReference/Welcome.html) | []() | Needs improvement
 [Config](https://aws.amazon.com/config/) | [rusoto_config](https://crates.io/crates/rusoto_config) | Needs improvement
 [Cost and Usage Report](https://aws.amazon.com/about-aws/whats-new/2015/12/aws-cost-and-usage-reports-comprehensive-and-customizable-reporting-on-your-aws-costs-and-cost-drivers/) | [rusoto_cur](https://crates.io/crates/rusoto_cur) | Needs improvement
 [Credential](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html) | [rusiti_credential](https://crates.io/crates/rusoto_credential) | Needs improvement
@@ -40,6 +44,7 @@ Service | Crate | Stability
 [ECS](https://aws.amazon.com/ecs/) | [rusoto_ecs](https://crates.io/crates/rusoto_ecs) | Stable
 [ElastiCache](https://aws.amazon.com/elasticache/) | [rusoto_elasticache](https://crates.io/crates/rusoto_elasticache) | Needs improvement
 [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/) | [rusoto_elasticbeanstalk](https://crates.io/crates/rusoto_elasticbeanstalk) | Needs improvement
+[Elastic File System](https://aws.amazon.com/efs/) | []() | Needs improvement
 [Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/) | [rusoto_elb](https://crates.io/crates/rusoto_elb) | Needs improvement
 [Elastic MapReduce](https://aws.amazon.com/elasticmapreduce/) | [rusoto_emr](https://crates.io/crates/rusoto_emr) | Needs improvement
 [Elastic Transcoder](https://aws.amazon.com/elastictranscoder/) | [rusoto_ets](https://crates.io/crates/rusoto_ets) | Stable
@@ -48,6 +53,8 @@ Service | Crate | Stability
 [Inspector](https://aws.amazon.com/inspector/) | [rusoto_inspector](https://crates.io/crates/rusoto_inspector) | Needs improvement
 [GameLift](https://aws.amazon.com/gamelift/) | [rusoto_gamelift](https://crates.io/crates/rusoto_gamelift) | Needs improvement
 [Glacier](https://aws.amazon.com/glacier/) | [rusoto_glacier](https://crates.io/crates/rusoto_glacier) | Needs improvement
+[Glue](https://aws.amazon.com/glue/) | []() | Needs improvement
+[Greengrass](https://aws.amazon.com/greengrass/) | []() | Needs improvement
 [Health APIs and Notifications](http://docs.aws.amazon.com/IAM/latest/UserGuide/list_health.html) | [rusoto_health](https://crates.io/crates/rusoto_health) | Needs improvement
 [IoT](https://aws.amazon.com/iot/) | [rusoto_iot](https://crates.io/crates/rusoto_iot) | Needs improvement
 [Key Management Service](https://aws.amazon.com/kms/) | [rusoto_kms](https://crates.io/crates/rusoto_kms) | Stable
@@ -58,6 +65,7 @@ Service | Crate | Stability
 [Lightsail](https://amazonlightsail.com/) | [rusoto_lightsail](https://crates.io/crates/rusoto_lightsail) | Needs improvement
 [Machine Learning](https://aws.amazon.com/machine-learning/) | [rusoto_machinelearning](https://crates.io/crates/rusoto_machinelearning) | Needs improvement
 [Marketplace Commerce Analytics](https://s3.amazonaws.com/awsmp-loadforms/AWS-Marketplace-Commerce-Analytics-Service-Onboarding-and-Technical-Guide.pdf) | [rusoto_marketplacecommerceanalytics](https://crates.io/crates/rusoto_marketplacecommerceanalytics) | Needs improvement
+[Marketplace Entitlement Service](http://docs.aws.amazon.com/marketplaceentitlement/latest/APIReference/Welcome.html) | []() | Needs improvement
 [Marketplace Metering](http://docs.aws.amazon.com/marketplacemetering/latest/APIReference/Welcome.html) | [rusoto_meteringmarketplace](https://crates.io/crates/rusoto_meteringmarketplace) | Needs improvement
 [Mechanical Turk](https://aws.amazon.com/documentation/mturk/) | [rusoto_mturk](https://crates.io/crates/rusoto_mturk) | Needs improvement
 [Migration Hub](https://aws.amazon.com/migration-hub/) | [rusoto_mgh]() | Needs improvement
@@ -73,6 +81,7 @@ Service | Crate | Stability
 [S3](https://aws.amazon.com/s3/) | [rusoto_s3](https://crates.io/crates/rusoto_s3) | Needs improvement
 [SDB](https://aws.amazon.com/simpledb/) | [rusoto_sdb](https://crates.io/crates/rusoto_sdb) | Needs improvement
 [Service Catalog](https://aws.amazon.com/servicecatalog/) | [rusoto_servicecatalog](https://crates.io/crates/rusoto_servicecatalog) | Needs improvement
+[Shield](https://aws.amazon.com/shield/) | []() | Needs improvement
 [Simple Email Service](https://aws.amazon.com/ses/) | [rusoto_ses](https://crates.io/crates/rusoto_ses) | Needs improvement
 [Simple Notification Service](https://aws.amazon.com/sns/) | [rusoto_sns](https://crates.io/crates/rusoto_sns) | Needs improvement
 [Simple Systems Manager](http://docs.aws.amazon.com/ssm/latest/APIReference/Welcome.html) | [rusoto_ssm](https://crates.io/crates/rusoto_ssm) | Needs improvement
@@ -87,4 +96,6 @@ Service | Crate | Stability
 [Support](http://docs.aws.amazon.com/awssupport/latest/user/Welcome.html) | [rusoto_support](https://crates.io/crates/rusoto_support) | Needs improvement
 [Web Application Firewall](https://aws.amazon.com/waf/) | [rusoto_waf](https://crates.io/crates/rusoto_waf) | Needs improvement
 [Web Application Firewall Regional](http://docs.aws.amazon.com/waf/latest/APIReference/API_Operations_AWS_WAF_Regional.html) | [rusoto_waf_regional](https://crates.io/crates/rusoto_waf_regional) | Needs improvement
+[Workdocs](https://aws.amazon.com/workdocs/) | []() | Needs improvement
 [WorkSpaces](https://aws.amazon.com/workspaces/) | [rusoto_workspaces](https://crates.io/crates/rusoto_workspaces) | Needs improvement
+[Xray](https://aws.amazon.com/xray/) | []() | Needs improvement


### PR DESCRIPTION
Update supported AWS services for Rusoto.

Question: There are support services which doesn't have a package on [crates.io](https://crates.io). How are those services treated? Add service without package link?