### PR TITLE
add docs to describe how to migrate to 0.38.0 error handling

### DIFF
--- a/rusoto_docs_tester/Cargo.toml
+++ b/rusoto_docs_tester/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Matthew Mayer <matthewkmayer@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-rusoto_core = "0.37"
-rusoto_ecs = "0.37"
-rusoto_dynamodb = "0.37"
-rusoto_s3 = "0.37"
+rusoto_core = "0.41"
+rusoto_ecs = "0.41"
+rusoto_dynamodb = "0.41"
+rusoto_s3 = "0.41"
 env_logger = "0.5"
 tokio-core = "0.1"
 futures = "0.1"

--- a/src/futures.md
+++ b/src/futures.md
@@ -35,7 +35,7 @@ extern crate rusoto_dynamodb;
 extern crate tokio_core;
 
 use futures::future::Future;
-use rusoto_core::Region;
+use rusoto_core::{Region, RusotoError};
 use rusoto_dynamodb::{
     AttributeDefinition, AttributeValue, CreateTableInput, CreateTableOutput, DynamoDb,
     DynamoDbClient, GetItemError, GetItemInput, GetItemOutput, KeySchemaElement,
@@ -100,7 +100,7 @@ fn make_upsert_item_future(
 fn make_get_item_future(
     client: &DynamoDbClient,
     item: &HashMap<String, AttributeValue>,
-) -> impl Future<Item = GetItemOutput, Error = GetItemError> {
+) -> impl Future<Item = GetItemOutput, Error = RusotoError<GetItemError>> {
     // future for getting the entry
     let get_item_request = GetItemInput {
         key: item.clone(),

--- a/src/migrations.md
+++ b/src/migrations.md
@@ -2,7 +2,7 @@
 
 ### Rusoto Versions < 0.38.0 to Versions >= 0.38.0 Error Handling
 Rusoto version 0.38.0 introduced the enum `rusoto_core::RusotoError`. In versions
-before 0.38.0 errors would be typed as themsevles such as  `rusoto_s3::CreateBucketError`.
+before 0.38.0 errors would be typed as themselves such as  `rusoto_s3::CreateBucketError`.
 In versions >= 0.38.0 the service method errors would be wrapped in the new enum,
 such as `rusoto_core::RusotoError<rusoto_s3::CreateBucketError>`.
 
@@ -42,7 +42,7 @@ fn create_bucket_sync(
 ```
 
 Rusoto >= 0.38.0:
-```rust, ignore
+```rust, no_run
 extern crate rusoto_core;
 extern crate rusoto_s3;
 


### PR DESCRIPTION
Am I missing anything here? Should I add an async example? 
Fixes #110 